### PR TITLE
Avoid clash with StdAny

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "downcast"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["Felix Köpge <fkoep@mailbox.org>"]
 license = "MIT"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,7 @@ fn to_trait_object<T: ?Sized>(obj: &T) -> TraitObject {
 pub trait Downcast<T>: Any
     where T: Any
 {
-    fn is_type(&self) -> bool { self.type_id() == TypeId::of::<T>() }
+    fn is_type(&self) -> bool { self::Any::type_id(self) == TypeId::of::<T>() }
 
     unsafe fn downcast_ref_unchecked(&self) -> &T { &*(to_trait_object(self).data as *mut T) }
 


### PR DESCRIPTION
Version change to 0.10 means that crates which need the compatibility fix won't get the fix.

This fixes 0.9 in a way that's backwards compatible.

https://github.com/rust-lang/rust/issues/58922